### PR TITLE
Allow default scheme to work without redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "index.js",
   "repository": {

--- a/src/default.js
+++ b/src/default.js
@@ -12,10 +12,6 @@ const STRATEGY = 'default'
 const OAUTH_PATHNAME = `/${STRATEGY}/oauth2`
 const OAUTH_CALLBACK_PATHNAME = `/${STRATEGY}/oauth2callback`
 
-const buildUrl = (url, params) => {
-	return `${url}?${Object.keys(params).map(k => `${k}=${encodeURIComponent(params[k])}`).join("&")}`
-}
-
 /**
  * Returns an Express handler that client directly requests.
  *
@@ -48,7 +44,7 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 			const verboseMessage = 'Missing required payload property. POST request must contain a \'user\' property in its JSON payload.'
 
 			if (errorRedirect)
-				res.redirect(buildUrl(errorRedirect, { code: 400, message, verboseMessage }))
+				res.redirect(addErrorToUrl(errorRedirect, { code: 400, message, verboseMessage }))
 			else
 				res.status(400).send(verboseMessage)
 
@@ -61,7 +57,7 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 			const verboseMessage = `Invalid payload. The type of the 'user' property in the JSON payload must be 'object' (current: '${typeof(user)}').`
 
 			if (errorRedirect)
-				res.redirect(buildUrl(errorRedirect, { code: 400, message, verboseMessage }))
+				res.redirect(addErrorToUrl(errorRedirect, { code: 400, message, verboseMessage }))
 			else
 				res.status(400).send(verboseMessage)
 

--- a/src/default.js
+++ b/src/default.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-const { idpHelp: { addErrorToUrl, authToUserPortal }, obj: { extractFlattenedJSON }, response:{ defaultErrorMessage, send } } = require('./utils')
+const { idpHelp: { addErrorToUrl, authToUserPortal }, obj: { extractFlattenedJSON }, response:{ defaultErrorMessage } } = require('./utils')
 
 const STRATEGY = 'default'
 const OAUTH_PATHNAME = `/${STRATEGY}/oauth2`
@@ -36,13 +36,13 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 		let errorRedirect = decodeURIComponent(errorRedirectUrl || onErrorRedirectUrl)
 		let successRedirect = decodeURIComponent(successRedirectUrl || onSuccessRedirectUrl)
 
-		errorRedirect = errorRedirect === "undefined" ? undefined : errorRedirect
-		successRedirect = successRedirect === "undefined" ? undefined : successRedirect
+		errorRedirect = errorRedirect === 'undefined' ? undefined : errorRedirect
+		successRedirect = successRedirect === 'undefined' ? undefined : successRedirect
 
-		const formatErrorUrl = errorRedirect ? args => addErrorToUrl(errorRedirect, args) : null;
+		const formatErrorUrl = errorRedirect ? args => addErrorToUrl(errorRedirect, args) : null
 
 		if (!user) {
-			const message = defaultErrorMessage;
+			const message = defaultErrorMessage
 			const verboseMessage = 'Missing required payload property. POST request must contain a \'user\' property in its JSON payload.'
 
 			if (formatErrorUrl)
@@ -55,7 +55,7 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 		}
 
 		if (typeof(user) != 'object') {		
-			const message = defaultErrorMessage;	
+			const message = defaultErrorMessage	
 			const verboseMessage = `Invalid payload. The type of the 'user' property in the JSON payload must be 'object' (current: '${typeof(user)}').`
 
 			if (formatErrorUrl)

--- a/src/default.js
+++ b/src/default.js
@@ -39,12 +39,14 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 		errorRedirect = errorRedirect === "undefined" ? undefined : errorRedirect
 		successRedirect = successRedirect === "undefined" ? undefined : successRedirect
 
+		const formatErrorUrl = errorRedirect ? args => addErrorToUrl(errorRedirect, args) : null;
+
 		if (!user) {
 			const message = defaultErrorMessage;
 			const verboseMessage = 'Missing required payload property. POST request must contain a \'user\' property in its JSON payload.'
 
-			if (errorRedirect)
-				res.redirect(addErrorToUrl(errorRedirect, { code: 400, message, verboseMessage }))
+			if (formatErrorUrl)
+				res.redirect(formatErrorUrl({ code: 400, message, verboseMessage }))
 			else
 				res.status(400).send(verboseMessage)
 
@@ -56,8 +58,8 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 			const message = defaultErrorMessage;	
 			const verboseMessage = `Invalid payload. The type of the 'user' property in the JSON payload must be 'object' (current: '${typeof(user)}').`
 
-			if (errorRedirect)
-				res.redirect(addErrorToUrl(errorRedirect, { code: 400, message, verboseMessage }))
+			if (formatErrorUrl)
+				res.redirect(formatErrorUrl({ code: 400, message, verboseMessage }))
 			else
 				res.status(400).send(verboseMessage)
 
@@ -65,7 +67,7 @@ const getAuthResponseHandler = ({ strategy, userPortal, redirectUrls }) => {
 			return 
 		}
 
-		authToUserPortal({ user, userPortal, strategy, successRedirect, errorRedirect, res, next })
+		authToUserPortal({ user, userPortal, strategy, successRedirect, formatErrorUrl, res, next })
 	}
 }
 

--- a/src/utils/idpHelp.js
+++ b/src/utils/idpHelp.js
@@ -48,7 +48,7 @@ const getCallbackUrl = (req, pathname, options) => {
 	return urlHelp.buildUrl(urlParams, { noEncoding:true })
 }
 
-const authToUserPortal = ({ user, userPortal, strategy, successRedirect, errorRedirect, res, next }) => {
+const authToUserPortal = ({ user, userPortal, strategy, successRedirect, formatErrorUrl, res, next }) => {
 	user = user || {}
 	user.strategy = strategy
 
@@ -77,8 +77,8 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, errorRe
 					const message = `${defaultErrorMessage} (code 001)`
 					const verboseMessage = `The ${strategy} OAuth succeeded, HTTP GET to 'userPortal.api' ${userPortal.api} successed to but did not return a 'token' value ({ "token": null }).`	
 					
-					if (errorRedirect)
-						res.redirect(addErrorToUrl(errorRedirect, { code: 400, message, verboseMessage }))
+					if (formatErrorUrl)
+						res.redirect(formatErrorUrl({ code: 400, message, verboseMessage }))
 					else
 						res.status(400).send(verboseMessage)
 				}
@@ -86,9 +86,9 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, errorRe
 				const message = typeof(data) == 'string' ? data : data ? (data.message || (data.error || {}).message || JSON.stringify(data)) : null
 				const verboseMessage = `The ${strategy} OAuth succeeded, but HTTP GET to 'userPortal.api' ${userPortal.api} failed.${message ? ` Details: ${message}` : ''}`;
 
-				if (errorRedirect)
+				if (formatErrorUrl)
 					res.redirect(
-						addErrorToUrl(errorRedirect, {
+						formatErrorUrl({
 							code: 400,
 							message: message || `${defaultErrorMessage} (code 002)`,
 							verboseMessage
@@ -98,9 +98,9 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, errorRe
 					res.status(400).send(verboseMessage)
 			}
 		}).catch(err => {
-			if (errorRedirect)
+			if (formatErrorUrl)
 				res.redirect(
-					addErrorToUrl(errorRedirect, {
+					formatErrorUrl({
 						code: 500,
 						message: `${defaultErrorMessage} (code 003)`,
 						verboseMessage: err.message

--- a/src/utils/idpHelp.js
+++ b/src/utils/idpHelp.js
@@ -77,14 +77,8 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, errorRe
 					const message = `${defaultErrorMessage} (code 001)`
 					const verboseMessage = `The ${strategy} OAuth succeeded, HTTP GET to 'userPortal.api' ${userPortal.api} successed to but did not return a 'token' value ({ "token": null }).`	
 					
-					if (errorRedirect) {
-						const urlInfo = urlHelp.getInfo(errorRedirect)
-						urlInfo.query = urlInfo.query || {}
-						urlInfo.query.message = message
-						urlInfo.query.verboseMessage = verboseMessage
-						urlInfo.query.code = 400
-						res.redirect(urlHelp.buildUrl(urlInfo))
-					}
+					if (errorRedirect)
+						res.redirect(addErrorToUrl(errorRedirect, { code: 400, message, verboseMessage }))
 					else
 						res.status(400).send(verboseMessage)
 				}
@@ -92,27 +86,27 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, errorRe
 				const message = typeof(data) == 'string' ? data : data ? (data.message || (data.error || {}).message || JSON.stringify(data)) : null
 				const verboseMessage = `The ${strategy} OAuth succeeded, but HTTP GET to 'userPortal.api' ${userPortal.api} failed.${message ? ` Details: ${message}` : ''}`;
 
-				if (errorRedirect) {
-					const urlInfo = urlHelp.getInfo(errorRedirect)
-					urlInfo.query = urlInfo.query || {}
-					urlInfo.query.message = message || `${defaultErrorMessage} (code 002)`
-					urlInfo.query.verboseMessage = verboseMessage;
-					urlInfo.query.code = 400
-					res.redirect(urlHelp.buildUrl(urlInfo))
-				}
-				else
+				if (errorRedirect)
+					res.redirect(
+						addErrorToUrl(errorRedirect, {
+							code: 400,
+							message: message || `${defaultErrorMessage} (code 002)`,
+							verboseMessage
+						})
+					)
+				else 
 					res.status(400).send(verboseMessage)
 			}
 		}).catch(err => {
-			if (errorRedirect) {
-				const urlInfo = urlHelp.getInfo(errorRedirect)
-				urlInfo.query = urlInfo.query || {};
-				urlInfo.query.message = `${defaultErrorMessage} (code 003)`
-				urlInfo.query.verboseMessage = err.message
-				urlInfo.query.code = 500
-				res.redirect(urlHelp.buildUrl(urlInfo))
-			}
-			else
+			if (errorRedirect)
+				res.redirect(
+					addErrorToUrl(errorRedirect, {
+						code: 500,
+						message: `${defaultErrorMessage} (code 003)`,
+						verboseMessage: err.message
+					})
+				)
+			else 
 				res.status(500).send(err.message)
 		}).then(next)
 	// 2.2. No external user portal defined. Return the IdP user to the client

--- a/src/utils/idpHelp.js
+++ b/src/utils/idpHelp.js
@@ -71,7 +71,7 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, formatE
 						res.redirect(urlHelp.buildUrl(urlInfo))
 					}
 					else
-						res.status(200).send(data.code);	
+						res.status(200).send(data.code)	
 				}
 				else {
 					const message = `${defaultErrorMessage} (code 001)`
@@ -84,7 +84,7 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, formatE
 				}
 			} else {
 				const message = typeof(data) == 'string' ? data : data ? (data.message || (data.error || {}).message || JSON.stringify(data)) : null
-				const verboseMessage = `The ${strategy} OAuth succeeded, but HTTP GET to 'userPortal.api' ${userPortal.api} failed.${message ? ` Details: ${message}` : ''}`;
+				const verboseMessage = `The ${strategy} OAuth succeeded, but HTTP GET to 'userPortal.api' ${userPortal.api} failed.${message ? ` Details: ${message}` : ''}`
 
 				if (formatErrorUrl)
 					res.redirect(

--- a/src/utils/idpHelp.js
+++ b/src/utils/idpHelp.js
@@ -75,7 +75,7 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, formatE
 				}
 				else {
 					const message = `${defaultErrorMessage} (code 001)`
-					const verboseMessage = `The ${strategy} OAuth succeeded, HTTP GET to 'userPortal.api' ${userPortal.api} successed to but did not return a 'token' value ({ "token": null }).`	
+					const verboseMessage = `The ${strategy} OAuth succeeded, HTTP POST to 'userPortal.api' ${userPortal.api} succeeded to but did not return a 'token' value ({ "token": null }).`	
 					
 					if (formatErrorUrl)
 						res.redirect(formatErrorUrl({ code: 400, message, verboseMessage }))
@@ -84,7 +84,7 @@ const authToUserPortal = ({ user, userPortal, strategy, successRedirect, formatE
 				}
 			} else {
 				const message = typeof(data) == 'string' ? data : data ? (data.message || (data.error || {}).message || JSON.stringify(data)) : null
-				const verboseMessage = `The ${strategy} OAuth succeeded, but HTTP GET to 'userPortal.api' ${userPortal.api} failed.${message ? ` Details: ${message}` : ''}`
+				const verboseMessage = `The ${strategy} OAuth succeeded, but HTTP POST to 'userPortal.api' ${userPortal.api} failed.${message ? ` Details: ${message}` : ''}`
 
 				if (formatErrorUrl)
 					res.redirect(


### PR DESCRIPTION
The `fetch` API in browsers and React Native will always follow redirects. This means that the client code will not be able to see the token response unless there is something listening on the success redirect (which is not always possible, or desirable).

This PR makes the `errorRedirect` and `successRedirect` optional for the `default` scheme. If there are no redirects, the error message or token is sent in the body of the current response.